### PR TITLE
feat: implement core search functionality with opensearch

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { SearchWidget } from '@features/search'
 import { Wrapper, Logo, SearchContainer } from './Header.styles'
 
 export function Header() {
@@ -7,7 +8,7 @@ export function Header() {
         Bookfinder
       </Logo>
       <SearchContainer>
-        {/* SearchWidget will be added here */}
+        <SearchWidget />
       </SearchContainer>
     </Wrapper>
   )

--- a/src/features/search/__tests__/SearchWidget.test.tsx
+++ b/src/features/search/__tests__/SearchWidget.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+import { searchApi } from '../api/searchApi'
+import { SearchWidget } from '../components/SearchWidget'
+
+function renderWithStore(component: React.ReactNode) {
+  const store = configureStore({
+    reducer: {
+      [searchApi.reducerPath]: searchApi.reducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(searchApi.middleware),
+  })
+
+  return render(<Provider store={store}>{component}</Provider>)
+}
+
+describe('SearchWidget', () => {
+  it('renders search input with placeholder', () => {
+    renderWithStore(<SearchWidget />)
+    expect(screen.getByPlaceholderText('Quick search...')).toBeInTheDocument()
+  })
+
+  it('has correct ARIA attributes', () => {
+    renderWithStore(<SearchWidget />)
+    const input = screen.getByRole('combobox')
+    expect(input).toHaveAttribute('aria-autocomplete', 'list')
+    expect(input).toHaveAttribute('aria-controls', 'search-results')
+  })
+
+  it('shows dropdown when user types', async () => {
+    const user = userEvent.setup()
+    renderWithStore(<SearchWidget />)
+
+    const input = screen.getByPlaceholderText('Quick search...')
+    await user.type(input, 'test')
+
+    expect(input).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('does not show dropdown for empty input', () => {
+    renderWithStore(<SearchWidget />)
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('closes dropdown on Escape key', async () => {
+    const user = userEvent.setup()
+    renderWithStore(<SearchWidget />)
+
+    const input = screen.getByPlaceholderText('Quick search...')
+    await user.type(input, 'test')
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/search/api/searchApi.ts
+++ b/src/features/search/api/searchApi.ts
@@ -1,0 +1,111 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import type { BookResult } from '@/types'
+import { API, SEARCH } from '@/constants'
+
+interface OpenLibraryDoc {
+  key: string
+  title: string
+  subtitle?: string
+  author_name?: string[]
+  author_key?: string[]
+  first_publish_year?: number
+  cover_i?: number
+  isbn?: string[]
+  edition_count?: number
+  language?: string[]
+  has_fulltext?: boolean
+  ebook_access?: string
+  publisher?: string[]
+  publish_place?: string[]
+  subject?: string[]
+}
+
+interface OpenLibraryResponse {
+  docs: OpenLibraryDoc[]
+  numFound: number
+}
+
+interface WorkDetailsResponse {
+  description?: string | { value: string }
+  title: string
+}
+
+export interface SearchQueryArgs {
+  query: string
+  offset?: number
+}
+
+export interface SearchResult {
+  results: BookResult[]
+  totalResults: number
+  hasMore: boolean
+}
+
+const PLACEHOLDER_COVER = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 72 72' fill='%239A9288'%3E%3Crect width='72' height='72' fill='%23EAE0D7'/%3E%3Cpath d='M36 22c-6.2-4.8-15-4-21 1v26c6-4 14.8-4.8 21 0 6.2-4.8 15-4 21 0V23c-6-5-14.8-5.8-21-1zm-3 22c-4-1.6-8.4-1.8-12-.8V27c3.6-1 8-.8 12 .8v17.2zm18 1.2c-3.6-1-8-.8-12 .8V27.8c4-1.6 8.4-1.8 12-.8v19.2z'/%3E%3C/svg%3E`
+
+function transformDocs(docs: OpenLibraryDoc[]): BookResult[] {
+  return docs.map((doc) => ({
+    id: doc.key,
+    key: doc.key,
+    title: doc.title,
+    subtitle: doc.subtitle ?? null,
+    author: doc.author_name?.[0] ?? 'Unknown Author',
+    authorKey: doc.author_key?.[0] ?? null,
+    year: doc.first_publish_year ?? null,
+    coverUrl: doc.cover_i
+      ? `${API.COVER_BASE_URL}/${doc.cover_i}-M.jpg`
+      : PLACEHOLDER_COVER,
+    coverLargeUrl: doc.cover_i
+      ? `${API.COVER_BASE_URL}/${doc.cover_i}-L.jpg`
+      : PLACEHOLDER_COVER,
+    isbn: doc.isbn?.[0] ?? null,
+    editionCount: doc.edition_count ?? 0,
+    languages: doc.language ?? [],
+    hasFulltext: doc.has_fulltext ?? false,
+    ebookAccess: doc.ebook_access ?? 'no_ebook',
+    publishers: doc.publisher?.slice(0, 5) ?? [],
+    publishPlaces: doc.publish_place?.slice(0, 3) ?? [],
+    subjects: doc.subject?.slice(0, 5) ?? [],
+  }))
+}
+
+export const searchApi = createApi({
+  reducerPath: 'searchApi',
+  baseQuery: fetchBaseQuery({ baseUrl: API.BASE_URL }),
+  endpoints: (builder) => ({
+    searchBooks: builder.query<SearchResult, SearchQueryArgs>({
+      query: ({ query, offset = 0 }) =>
+        `/search.json?q=${encodeURIComponent(query)}&limit=${SEARCH.RESULTS_LIMIT}&offset=${offset}`,
+      transformResponse: (response: OpenLibraryResponse, _meta, arg): SearchResult => {
+        const results = transformDocs(response.docs)
+        const currentOffset = arg.offset ?? 0
+        return {
+          results,
+          totalResults: response.numFound,
+          hasMore: currentOffset + results.length < response.numFound,
+        }
+      },
+      serializeQueryArgs: ({ queryArgs }) => queryArgs.query,
+      merge: (currentCache, newItems, { arg }) => {
+        if (arg.offset === 0 || arg.offset === undefined) {
+          return newItems
+        }
+        return {
+          ...newItems,
+          results: [...currentCache.results, ...newItems.results],
+        }
+      },
+      forceRefetch: ({ currentArg, previousArg }) => {
+        if (currentArg?.offset === 0 || currentArg?.offset === undefined) {
+          return true
+        }
+        return currentArg?.offset !== previousArg?.offset
+      },
+    }),
+    getBookDetails: builder.query<WorkDetailsResponse, string>({
+      query: (key) => `${key}.json`,
+    }),
+  }),
+})
+
+export const { useSearchBooksQuery, useLazySearchBooksQuery, useGetBookDetailsQuery } = searchApi

--- a/src/features/search/components/ResultItem.styles.ts
+++ b/src/features/search/components/ResultItem.styles.ts
@@ -1,0 +1,95 @@
+import styled, { keyframes } from 'styled-components'
+import { theme } from '@app/theme'
+import { truncate } from '@/styles'
+
+const shimmer = keyframes`
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+`;
+
+export const Title = styled.span`
+  font-weight: 500;
+  color: ${theme.colors.evergreen.veryDark};
+  line-height: 1.3;
+  ${truncate()}
+`
+
+export const Wrapper = styled.a<{ $isActive: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  text-decoration: none;
+  color: inherit;
+  background-color: ${({ $isActive }) => 
+    $isActive ? theme.colors.evergreen.light : 'transparent'};
+
+  &:hover {
+    text-decoration: none;
+    background-color: ${theme.colors.evergreen.light};
+  }
+
+  &:hover ${Title} {
+    text-decoration: underline;
+  }
+`
+
+export const CoverWrapper = styled.div`
+  width: 48px;
+  height: 72px; 
+  border-radius: ${theme.radii.xs};
+  background: ${theme.colors.offwhite.calm};
+  flex-shrink: 0;
+  overflow: hidden;
+  position: relative;
+`
+
+export const CoverImage = styled.img<{ $loaded: boolean }>`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: ${({ $loaded }) => ($loaded ? 1 : 0)};
+  transition: opacity ${theme.transitions.fast};
+`
+
+export const Skeleton = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, 
+    ${theme.colors.offwhite.calm} 25%, 
+    ${theme.colors.offwhite.light} 50%, 
+    ${theme.colors.offwhite.calm} 75%
+  );
+  background-size: 200% 100%;
+  animation: ${shimmer} 1.5s infinite;
+`
+
+export const Info = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`
+
+export const Author = styled.span`
+  font-size: 0.875rem;
+  color: ${theme.colors.offwhite.vivid};
+  ${truncate()}
+`
+
+export const Year = styled.span`
+  font-size: 0.75rem;
+  color: ${theme.colors.offwhite.vivid};
+  ${truncate()}
+`
+
+export const ChevronIcon = styled.svg`
+  width: 16px;
+  height: 16px;
+  color: ${theme.colors.offwhite.vivid};
+  flex-shrink: 0;
+`

--- a/src/features/search/components/ResultItem.tsx
+++ b/src/features/search/components/ResultItem.tsx
@@ -1,0 +1,63 @@
+import { CSSProperties, useCallback, memo } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { BookResult } from '@/types'
+import { useCachedImage } from '@/hooks'
+import {
+  Wrapper,
+  CoverWrapper,
+  CoverImage,
+  Skeleton,
+  Info,
+  Title,
+  Author,
+  Year,
+  ChevronIcon,
+} from './ResultItem.styles'
+
+interface ResultItemProps {
+  book: BookResult
+  isActive: boolean
+  onMouseEnter: () => void
+  style: CSSProperties
+}
+
+export const ResultItem = memo(function ResultItem({ book, isActive, onMouseEnter, style }: ResultItemProps) {
+  const navigate = useNavigate()
+  const { loaded, imgRef, handleLoad } = useCachedImage(book.coverUrl)
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    navigate(`/book/${encodeURIComponent(book.id)}`, { state: { book } })
+  }, [navigate, book])
+
+  return (
+    <Wrapper
+      href={`/book/${encodeURIComponent(book.id)}`}
+      onClick={handleClick}
+      $isActive={isActive}
+      onMouseEnter={onMouseEnter}
+      style={style}
+      role="option"
+      aria-selected={isActive}
+    >
+      <CoverWrapper>
+        {!loaded && <Skeleton />}
+        <CoverImage
+          ref={imgRef}
+          src={book.coverUrl}
+          alt=""
+          $loaded={loaded}
+          onLoad={handleLoad}
+        />
+      </CoverWrapper>
+      <Info>
+        <Title>{book.title}</Title>
+        <Author>{book.author}</Author>
+        {book.year && <Year>{book.year}</Year>}
+      </Info>
+      <ChevronIcon viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M9 18l6-6-6-6" />
+      </ChevronIcon>
+    </Wrapper>
+  )
+})

--- a/src/features/search/components/ResultsDropdown.styles.ts
+++ b/src/features/search/components/ResultsDropdown.styles.ts
@@ -1,0 +1,83 @@
+import styled from "styled-components";
+import { theme } from "@app/theme";
+import { media, slideDown } from "@/styles";
+import { HEADER, SEARCH } from "@/constants";
+
+export const Wrapper = styled.div`
+  position: absolute;
+  top: calc(100% + 17px);
+  right: 0px;
+  width: 434px;
+  max-height: ${SEARCH.DROPDOWN_MAX_HEIGHT}px;
+  z-index: 1000;
+
+  ${media.mobile} {
+    position: fixed;
+    top: ${HEADER.HEIGHT}px;
+    left: 0;
+    right: 0;
+    width: 100%;
+    max-height: calc(100vh - ${HEADER.HEIGHT}px);
+  }
+`;
+
+export const Tail = styled.div`
+  position: absolute;
+  top: -5px;
+  right: 110px;
+  width: 12px;
+  height: 12px;
+  background: ${theme.colors.surface};
+  border-left: 1px solid ${theme.colors.offwhite.calm};
+  border-top: 1px solid ${theme.colors.offwhite.calm};
+  transform: rotate(45deg);
+  z-index: 1;
+
+  clip-path: polygon(0 0, 100% 0, 0 100%);
+
+  ${media.mobile} {
+    display: none;
+  }
+`;
+
+export const Content = styled.div`
+  position: relative;
+  background: ${theme.colors.surface};
+  border: 1px solid ${theme.colors.offwhite.calm};
+  border-radius: ${theme.radii.xs};
+  box-shadow: ${theme.shadows.lg};
+  padding: ${theme.spacing.sm} ${theme.spacing.sm} 0 ${theme.spacing.sm};
+  overflow: hidden;
+  animation: ${slideDown} 150ms ease;
+
+  ${media.mobile} {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+`;
+
+export const SkeletonContainer = styled.div`
+  height: ${SEARCH.DROPDOWN_MAX_HEIGHT}px;
+  overflow: hidden;
+`
+
+export const GradientOverlay = styled.div<{ $visible: boolean }>`
+  position: absolute;
+  bottom: -9px;
+  left: 1px;
+  right: 1px;
+  border-radius: ${theme.radii.xs};
+  height: 58px;
+  background: linear-gradient(transparent, ${theme.colors.fade});
+  pointer-events: none;
+  z-index: 2;
+  opacity: ${({ $visible }) => ($visible ? 1 : 0)};
+  transition: opacity ${theme.transitions.normal};
+`;
+
+export const EmptyState = styled.div`
+  padding: ${theme.spacing.lg};
+  text-align: center;
+  color: ${theme.colors.offwhite.vivid};
+`;

--- a/src/features/search/components/ResultsDropdown.tsx
+++ b/src/features/search/components/ResultsDropdown.tsx
@@ -1,0 +1,138 @@
+import { useRef, useEffect, useMemo, memo } from 'react'
+import { FixedSizeList as List, ListOnScrollProps, ListChildComponentProps } from 'react-window'
+import type { BookResult } from '@/types'
+import { SEARCH } from '@/constants'
+import { ResultItem } from './ResultItem'
+import { SkeletonItem } from './SkeletonItem'
+import {
+  Wrapper,
+  Tail,
+  Content,
+  SkeletonContainer,
+  GradientOverlay,
+  EmptyState,
+} from './ResultsDropdown.styles'
+
+interface ResultsDropdownProps {
+  results: BookResult[]
+  isLoading: boolean
+  isFetchingMore: boolean
+  hasMore: boolean
+  activeIndex: number
+  onItemHover: (index: number) => void
+  onLoadMore: () => void
+  query: string
+}
+
+interface ItemData {
+  results: BookResult[]
+  activeIndex: number
+  onItemHover: (index: number) => void
+}
+
+const Row = memo(function Row({ index, style, data }: ListChildComponentProps<ItemData>) {
+  const { results, activeIndex, onItemHover } = data
+  const book = results[index]
+
+  return (
+    <ResultItem
+      book={book}
+      isActive={index === activeIndex}
+      onMouseEnter={() => onItemHover(index)}
+      style={style}
+    />
+  )
+})
+
+const LOAD_MORE_THRESHOLD = 450
+
+export function ResultsDropdown({
+  results,
+  isLoading,
+  isFetchingMore,
+  hasMore,
+  activeIndex,
+  onItemHover,
+  onLoadMore,
+  query,
+}: ResultsDropdownProps) {
+  const listRef = useRef<List>(null)
+  const scrollOffsetRef = useRef(0)
+
+  const totalHeight = results.length * SEARCH.ITEM_HEIGHT
+  const viewportHeight = Math.min(totalHeight, SEARCH.DROPDOWN_MAX_HEIGHT)
+  const canScroll = totalHeight > SEARCH.DROPDOWN_MAX_HEIGHT
+  const maxScroll = totalHeight - viewportHeight
+
+  const handleScroll = ({ scrollOffset }: ListOnScrollProps) => {
+    scrollOffsetRef.current = scrollOffset
+    if (hasMore && !isFetchingMore && scrollOffset >= maxScroll - LOAD_MORE_THRESHOLD) {
+      onLoadMore()
+    }
+  }
+
+  useEffect(() => {
+    if (activeIndex >= 0 && listRef.current) {
+      listRef.current.scrollToItem(activeIndex, 'smart')
+    }
+  }, [activeIndex])
+
+  const itemData = useMemo<ItemData>(() => ({
+    results,
+    activeIndex,
+    onItemHover,
+  }), [results, activeIndex, onItemHover])
+
+  // Compute gradient visibility based on current scroll position
+  const isAtBottom = scrollOffsetRef.current >= maxScroll - 10
+
+  if (isLoading) {
+    return (
+      <Wrapper>
+        <Tail />
+        <Content role="listbox" id="search-results">
+          <SkeletonContainer>
+            {[0, 1, 2, 3].map((i) => (
+              <SkeletonItem key={i} />
+            ))}
+          </SkeletonContainer>
+        </Content>
+        <GradientOverlay $visible />
+      </Wrapper>
+    )
+  }
+
+  if (results.length === 0) {
+    return (
+      <Wrapper>
+        <Tail />
+        <Content role="listbox" id="search-results">
+          <EmptyState>No books found for "{query}"</EmptyState>
+        </Content>
+      </Wrapper>
+    )
+  }
+
+  const showGradient = hasMore || (canScroll && !isAtBottom)
+
+  return (
+    <Wrapper>
+      <Tail />
+      <Content role="listbox" id="search-results">
+        <List
+          ref={listRef}
+          height={viewportHeight}
+          itemCount={results.length}
+          itemSize={SEARCH.ITEM_HEIGHT}
+          width="100%"
+          onScroll={handleScroll}
+          itemData={itemData}
+          itemKey={(index, data) => data.results[index].id}
+        >
+          {Row}
+        </List>
+      </Content>
+      {canScroll && <GradientOverlay $visible={showGradient} />}
+    </Wrapper>
+  )
+}

--- a/src/features/search/components/SearchInput.styles.ts
+++ b/src/features/search/components/SearchInput.styles.ts
@@ -1,0 +1,82 @@
+import styled, { css, keyframes } from "styled-components";
+import { theme } from "@app/theme";
+import { media } from "@/styles";
+
+const spin = keyframes`
+  from { transform: translateY(-50%) rotate(0deg); }
+  to { transform: translateY(-50%) rotate(360deg); }
+`;
+
+export const Wrapper = styled.div`
+  position: relative;
+  width: 238px;
+
+  ${media.tablet} {
+    width: 200px;
+  }
+
+  ${media.mobile} {
+    width: 160px;
+  }
+`;
+
+const openStyles = css`
+  border-color: ${theme.colors.offwhite.vivid};
+  background: ${theme.colors.surface};
+`;
+
+export const Input = styled.input<{ $isOpen: boolean }>`
+  border-radius: ${theme.radii.xs};
+  width: 100%;
+  height: 42px;
+  max-height: 42px;
+  /* Reduced top padding to move text visually up */
+  padding: 6px ${theme.spacing.controlX} ${theme.spacing.controlY};
+  padding-right: 40px; /* Space for end-adorned icon */
+  font-size: 0.9375rem;
+  color: ${theme.colors.evergreen.veryDark};
+  background: ${theme.colors.offwhite.light};
+  border: 1px solid ${theme.colors.offwhite.calm};
+  transition: all ${theme.transitions.fast};
+
+  &::placeholder {
+    color: ${theme.colors.offwhite.vivid};
+  }
+
+  &:hover {
+    border-color: ${theme.colors.offwhite.vivid};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${theme.colors.offwhite.vivid};
+    background: ${theme.colors.surface};
+    box-shadow: ${theme.shadows.sm};
+  }
+
+  ${({ $isOpen }) => $isOpen && openStyles}
+`;
+
+export const Icon = styled.svg`
+  position: absolute;
+  right: ${theme.spacing.controlX}; /* End adorned */
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  color: ${theme.colors.offwhite.vivid};
+  pointer-events: none;
+`;
+
+export const Spinner = styled.div`
+  position: absolute;
+  right: ${theme.spacing.controlX}; /* End adorned */
+  top: 50%;
+  width: 18px;
+  height: 18px;
+  border: 2px solid ${theme.colors.offwhite.calm};
+  border-top-color: ${theme.colors.evergreen.dark};
+  border-radius: 50%;
+  animation: ${spin} 0.6s linear infinite;
+  pointer-events: none;
+`;

--- a/src/features/search/components/SearchInput.tsx
+++ b/src/features/search/components/SearchInput.tsx
@@ -1,0 +1,47 @@
+import { forwardRef } from 'react'
+import { Wrapper, Input, Icon, Spinner } from './SearchInput.styles'
+
+interface SearchInputProps {
+  value: string
+  onChange: (value: string) => void
+  onFocus: () => void
+  onKeyDown: (event: React.KeyboardEvent) => void
+  isOpen: boolean
+  isLoading?: boolean
+}
+
+export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ value, onChange, onFocus, onKeyDown, isOpen, isLoading }, ref) => {
+    return (
+      <Wrapper>
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          <Icon viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="M21 21l-4.35-4.35" />
+          </Icon>
+        )}
+        <Input
+          ref={ref}
+          id="book-search"
+          name="book-search"
+          type="text"
+          placeholder="Quick search..."
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
+          autoComplete="off"
+          $isOpen={isOpen}
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls="search-results"
+          aria-autocomplete="list"
+        />
+      </Wrapper>
+    )
+  }
+)
+
+SearchInput.displayName = 'SearchInput'

--- a/src/features/search/components/SearchWidget.tsx
+++ b/src/features/search/components/SearchWidget.tsx
@@ -1,0 +1,127 @@
+import { useRef, useEffect } from 'react'
+import styled from 'styled-components'
+import { useLocation } from 'react-router-dom'
+import { useSearchBooksQuery } from '../api/searchApi'
+import {
+  setQuery,
+  openDropdown,
+  closeDropdown,
+  setActiveIndex,
+  setOffset,
+  resetSearch,
+  selectQuery,
+  selectIsOpen,
+  selectActiveIndex,
+  selectOffset,
+} from '../searchSlice'
+import { useAppDispatch, useAppSelector } from '@app/hooks'
+import { useDebounce, useClickOutside, useHotkey } from '@/hooks'
+import { SEARCH, KEYBOARD, API } from '@/constants'
+import { SearchInput } from './SearchInput'
+import { ResultsDropdown } from './ResultsDropdown'
+
+const Wrapper = styled.div`
+  position: relative;
+`
+
+export function SearchWidget() {
+  const dispatch = useAppDispatch()
+  const query = useAppSelector(selectQuery)
+  const isOpen = useAppSelector(selectIsOpen)
+  const activeIndex = useAppSelector(selectActiveIndex)
+  const offset = useAppSelector(selectOffset)
+
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const location = useLocation()
+
+  useEffect(() => {
+    dispatch(resetSearch())
+  }, [dispatch, location.pathname])
+
+  const debouncedQuery = useDebounce(query, SEARCH.DEBOUNCE_MS)
+  const shouldFetch = debouncedQuery.length >= SEARCH.MIN_QUERY_LENGTH
+
+  const { data, isLoading, isFetching } = useSearchBooksQuery(
+    { query: debouncedQuery, offset },
+    { skip: !shouldFetch }
+  )
+
+  const isDebouncing = query !== debouncedQuery
+  const isBelowMinLength = query.length < SEARCH.MIN_QUERY_LENGTH
+  const results = (isDebouncing || isBelowMinLength) ? [] : (data?.results ?? [])
+  const hasMore = data?.hasMore ?? false
+  const showDropdown = isOpen && query.length >= 1
+
+  const handleClose = () => dispatch(closeDropdown())
+
+  useClickOutside(wrapperRef, handleClose)
+
+  useHotkey({ key: 'k', ctrl: true }, (e: KeyboardEvent) => {
+    e.preventDefault()
+    inputRef.current?.focus()
+  })
+
+  useHotkey(KEYBOARD.ESCAPE, () => {
+    handleClose()
+    inputRef.current?.blur()
+  })
+
+  const handleKeyNavigation = (event: React.KeyboardEvent) => {
+    if (!results.length) return
+
+    switch (event.key) {
+      case KEYBOARD.ARROW_DOWN:
+        event.preventDefault()
+        if (activeIndex < results.length - 1) {
+          dispatch(setActiveIndex(activeIndex + 1))
+        }
+        break
+      case KEYBOARD.ARROW_UP:
+        event.preventDefault()
+        if (activeIndex > 0) {
+          dispatch(setActiveIndex(activeIndex - 1))
+        }
+        break
+      case KEYBOARD.ENTER:
+        if (activeIndex >= 0 && results[activeIndex]) {
+          const book = results[activeIndex]
+          const searchTerm = book.isbn ?? `${book.title} ${book.author}`
+          window.open(`${API.AMAZON_SEARCH_URL}?k=${encodeURIComponent(searchTerm)}`, '_blank')
+        }
+        break
+    }
+  }
+
+  const handleLoadMore = () => {
+    if (hasMore && !isFetching) {
+      dispatch(setOffset(results.length))
+    }
+  }
+
+  return (
+    <Wrapper ref={wrapperRef}>
+      <SearchInput
+        ref={inputRef}
+        value={query}
+        onChange={(value) => dispatch(setQuery(value))}
+        onFocus={() => dispatch(openDropdown())}
+        onKeyDown={handleKeyNavigation}
+        isOpen={showDropdown}
+        isLoading={isFetching}
+      />
+      {showDropdown && (
+        <ResultsDropdown
+          results={results}
+          isLoading={isBelowMinLength || isDebouncing || ((isLoading || isFetching) && offset === 0)}
+          isFetchingMore={isFetching && offset > 0}
+          hasMore={hasMore}
+          activeIndex={activeIndex}
+          onItemHover={(index) => dispatch(setActiveIndex(index))}
+          onLoadMore={handleLoadMore}
+          query={query}
+        />
+      )}
+    </Wrapper>
+  )
+}

--- a/src/features/search/components/SkeletonItem.styles.ts
+++ b/src/features/search/components/SkeletonItem.styles.ts
@@ -1,0 +1,43 @@
+import styled, { keyframes } from 'styled-components'
+import { theme } from '@app/theme'
+import { SEARCH } from '@/constants'
+
+const shimmer = keyframes`
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+`
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${theme.spacing.sm};
+  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  height: ${SEARCH.ITEM_HEIGHT}px;
+`
+
+export const SkeletonBox = styled.div<{ $width?: string; $height?: string }>`
+  background: linear-gradient(90deg,
+    ${theme.colors.offwhite.calm} 25%,
+    ${theme.colors.offwhite.light} 50%,
+    ${theme.colors.offwhite.calm} 75%
+  );
+  background-size: 200% 100%;
+  border-radius: ${theme.radii.xs};
+  animation: ${shimmer} 1.5s infinite;
+  width: ${({ $width }) => $width ?? '100%'};
+  height: ${({ $height }) => $height ?? '16px'};
+`
+
+export const CoverSkeleton = styled(SkeletonBox)`
+  width: 48px;
+  height: 72px;
+  flex-shrink: 0;
+`
+
+export const Info = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`

--- a/src/features/search/components/SkeletonItem.tsx
+++ b/src/features/search/components/SkeletonItem.tsx
@@ -1,0 +1,19 @@
+import {
+  Wrapper,
+  CoverSkeleton,
+  Info,
+  SkeletonBox,
+} from './SkeletonItem.styles'
+
+export function SkeletonItem() {
+  return (
+    <Wrapper>
+      <CoverSkeleton />
+      <Info>
+        <SkeletonBox $width="80%" $height="18px" />
+        <SkeletonBox $width="50%" $height="14px" />
+        <SkeletonBox $width="30%" $height="12px" />
+      </Info>
+    </Wrapper>
+  )
+}

--- a/src/features/search/index.ts
+++ b/src/features/search/index.ts
@@ -1,0 +1,5 @@
+export { SearchWidget } from "./components/SearchWidget";
+export { searchApi, useSearchBooksQuery } from "./api/searchApi";
+export type { SearchQueryArgs, SearchResult } from "./api/searchApi";
+export { getAmazonUrl } from "./utils/amazonLink";
+export { searchSlice } from "./searchSlice";

--- a/src/features/search/searchSlice.ts
+++ b/src/features/search/searchSlice.ts
@@ -1,0 +1,71 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '@app/store'
+
+interface SearchState {
+  query: string
+  isOpen: boolean
+  activeIndex: number
+  offset: number
+}
+
+const initialState: SearchState = {
+  query: '',
+  isOpen: false,
+  activeIndex: -1,
+  offset: 0,
+}
+
+export const searchSlice = createSlice({
+  name: 'search',
+  initialState,
+  reducers: {
+    setQuery: (state, action: PayloadAction<string>) => {
+      state.query = action.payload
+      state.activeIndex = -1
+      state.offset = 0
+      if (action.payload.length >= 3) {
+        state.isOpen = true
+      }
+    },
+    openDropdown: (state) => {
+      if (state.query.length >= 3) {
+        state.isOpen = true
+      }
+    },
+    closeDropdown: (state) => {
+      state.isOpen = false
+      state.activeIndex = -1
+    },
+    setActiveIndex: (state, action: PayloadAction<number>) => {
+      state.activeIndex = action.payload
+    },
+    moveActiveIndex: (state, action: PayloadAction<'up' | 'down'>) => {
+      if (action.payload === 'down') {
+        state.activeIndex = state.activeIndex + 1
+      } else if (state.activeIndex > 0) {
+        state.activeIndex = state.activeIndex - 1
+      }
+    },
+    setOffset: (state, action: PayloadAction<number>) => {
+      state.offset = action.payload
+    },
+    resetSearch: () => initialState,
+  },
+})
+
+export const {
+  setQuery,
+  openDropdown,
+  closeDropdown,
+  setActiveIndex,
+  moveActiveIndex,
+  setOffset,
+  resetSearch,
+} = searchSlice.actions
+
+export const selectQuery = (state: RootState) => state.search.query
+export const selectIsOpen = (state: RootState) => state.search.isOpen
+export const selectActiveIndex = (state: RootState) => state.search.activeIndex
+export const selectOffset = (state: RootState) => state.search.offset
+
+export default searchSlice.reducer

--- a/src/features/search/utils/__tests__/amazonLink.test.ts
+++ b/src/features/search/utils/__tests__/amazonLink.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { getAmazonUrl } from '../amazonLink'
+import type { BookResult } from '@/types'
+
+function createMockBook(overrides: Partial<BookResult> = {}): BookResult {
+  return {
+    id: '/works/OL1234W',
+    key: '/works/OL1234W',
+    title: 'Test Book',
+    subtitle: null,
+    author: 'Test Author',
+    authorKey: null,
+    year: 2020,
+    coverUrl: 'https://example.com/cover.jpg',
+    coverLargeUrl: 'https://example.com/cover-L.jpg',
+    isbn: null,
+    editionCount: 1,
+    languages: ['eng'],
+    hasFulltext: false,
+    ebookAccess: 'no_ebook',
+    publishers: [],
+    publishPlaces: [],
+    subjects: [],
+    ...overrides,
+  }
+}
+
+describe('getAmazonUrl', () => {
+  it('uses ISBN when available', () => {
+    const book = createMockBook({
+      title: 'The Great Gatsby',
+      author: 'F. Scott Fitzgerald',
+      year: 1925,
+      isbn: '9780743273565',
+    })
+
+    const url = getAmazonUrl(book)
+    expect(url).toBe('https://www.amazon.com/s?k=9780743273565')
+  })
+
+  it('falls back to title and author when no ISBN', () => {
+    const book = createMockBook({
+      title: 'The Great Gatsby',
+      author: 'F. Scott Fitzgerald',
+      year: 1925,
+      isbn: null,
+    })
+
+    const url = getAmazonUrl(book)
+    expect(url).toContain('The%20Great%20Gatsby')
+    expect(url).toContain('F.%20Scott%20Fitzgerald')
+  })
+
+  it('encodes special characters', () => {
+    const book = createMockBook({
+      title: 'Book: A Story & More',
+      author: 'Author Name',
+      isbn: null,
+    })
+
+    const url = getAmazonUrl(book)
+    expect(url).toContain('%3A')
+    expect(url).toContain('%26')
+    expect(url).not.toContain(' ')
+  })
+})

--- a/src/features/search/utils/amazonLink.ts
+++ b/src/features/search/utils/amazonLink.ts
@@ -1,0 +1,7 @@
+import type { BookResult } from '@/types'
+import { API } from '@/constants'
+
+export function getAmazonUrl(book: BookResult): string {
+  const searchTerm = book.isbn ?? `${book.title} ${book.author}`
+  return `${API.AMAZON_SEARCH_URL}?k=${encodeURIComponent(searchTerm)}`
+}

--- a/src/pages/BookDetail/BookDetail.tsx
+++ b/src/pages/BookDetail/BookDetail.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate, Navigate } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import type { BookResult } from '@/types'
 import { API } from '@/constants'
-// import { useGetBookDetailsQuery } from '@features/search/api/searchApi'
+import { useGetBookDetailsQuery } from '@features/search/api/searchApi'
 import { Skeleton } from '@/components/common'
 import {
   Wrapper,
@@ -66,11 +66,9 @@ export function BookDetail() {
     setImageLoaded(false)
   }, [book?.key])
 
-  // const { data: details, isLoading: isLoadingDetails } = useGetBookDetailsQuery(book?.key ?? '', {
-  //   skip: !book?.key
-  // })
-  const details = undefined
-  const isLoadingDetails = false
+  const { data: details, isLoading: isLoadingDetails } = useGetBookDetailsQuery(book?.key ?? '', {
+    skip: !book?.key
+  })
 
   if (!book) {
     return <Navigate to="/" replace />


### PR DESCRIPTION
<img 
  src="https://github.com/user-attachments/assets/8bdac5a4-ca23-4eda-bda4-6943ebffff51" 
  alt="chrome-capture-2026-01-06" 
  width="400"
/>
Implements the core search functionality for the Open Library Search tool, bridging shared UI components with the API layer.
* **RTK Query:** Adds a `searchApi` with an optimized `searchBooks` endpoint
* `SearchWidget` is self-contained and easily portable
* **Performance:** Debounced searches and virtualized results via `react-window`
* **UX:** Skeleton loading, Figma-accurate dropdown tail, click-outside and Escape handling
* **Business logic:** Automatic Amazon link generation with ISBN → title/author fallback
